### PR TITLE
Added

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimDelegateNotify.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimDelegateNotify.cpp
@@ -1,0 +1,6 @@
+#include "AnimDelegateNotify.h"
+
+void UAnimDelegateNotify::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+{
+    OnNotifyTriggered.Broadcast(MeshComp, Animation);
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimDelegateNotify.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimDelegateNotify.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "AnimNotify.h"
+
+DECLARE_MULTICAST_DELEGATE_TwoParams(FOnAnimNotify, USkeletalMeshComponent*, UAnimSequenceBase*);
+
+
+class UAnimDelegateNotify : public UAnimNotify
+{
+    DECLARE_CLASS(UAnimDelegateNotify, UAnimNotify)
+public:
+    UAnimDelegateNotify() = default;
+
+    /**
+     * Notify가 실행될 때 호출되는 함수 (엔진이 자동으로 호출)
+     * 여기서 델리게이트를 브로드캐스트한다.
+     */
+    virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation) override;
+
+public:
+    /** 이 Notify에 바인딩할 수 있는 델리게이트 */
+    FOnAnimNotify OnNotifyTriggered;
+};
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimSequenceBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Animation/AnimSequenceBase.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "AnimationAsset.h"
 
+#include "AnimDelegateNotify.h"
+
 class UAnimDataController;
 class UAnimDataModel;
 struct FAnimNotifyEvent;
@@ -57,3 +59,51 @@ public:
 private:
     void CreateModel();
 };
+
+
+template <typename UserClass>
+bool UAnimSequenceBase::AddDelegateNotifyEventAndBind(
+    int32 TargetTrackIndex, float Time, UserClass* InUserObject, void(UserClass::* InFunction)(USkeletalMeshComponent*, UAnimSequenceBase*),
+    int32& OutNewNotifyIndex
+)
+{
+    OutNewNotifyIndex = INDEX_NONE;
+
+    // 1) Track 인덱스 유효성 검사
+    if (!AnimNotifyTracks.IsValidIndex(TargetTrackIndex) || InUserObject == nullptr || InFunction == nullptr)
+    {
+        return false;
+    }
+
+    // 2) DelegateNotify용 이름, Duration=0
+    static const FName DelegateNotifyName(TEXT("DelegateNotify"));
+    float Duration = 0.f;
+
+    // 3) 기본 AddNotifyEvent 호출
+    bool bAdded = AddNotifyEvent(TargetTrackIndex, Time, Duration, DelegateNotifyName, OutNewNotifyIndex);
+    if (!bAdded || OutNewNotifyIndex == INDEX_NONE)
+    {
+        return false;
+    }
+
+    // 4) 새로 생성된 FAnimNotifyEvent 가져오기
+    FAnimNotifyEvent* NewEvent = GetNotifyEvent(OutNewNotifyIndex);
+    if (NewEvent == nullptr)
+    {
+        return false;
+    }
+
+    // 5) UAnimDelegateNotify 객체 생성 후 연결
+    UAnimDelegateNotify* DelegateNotifyObj =
+        FObjectFactory::ConstructObject<UAnimDelegateNotify>(this);
+    if (DelegateNotifyObj == nullptr)
+    {
+        return false;
+    }
+    NewEvent->SetAnimNotify(DelegateNotifyObj);
+
+    // 6) 바인딩: 정적 멀티캐스트 델리게이트에 InUserObject, InFunction 등록
+    DelegateNotifyObj->OnNotifyTriggered.AddUObject(InUserObject, InFunction);
+
+    return true;
+}

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -305,6 +305,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Animation\AnimDelegateNotify.cpp" />
     <ClCompile Include="Engine\Contents\AnimInstance\LuaScriptAnimInstance.cpp" />
     <ClCompile Include="Engine\Contents\Maps\MapModule.cpp" />
     <ClCompile Include="Engine\Contents\Objects\DamageCameraShake.cpp" />
@@ -654,6 +655,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Animation\AnimDelegateNotify.h" />
     <ClInclude Include="Engine\Contents\AnimInstance\LuaScriptAnimInstance.h" />
     <ClInclude Include="Engine\Contents\Maps\MapModule.h" />
     <ClInclude Include="Engine\Contents\Objects\DamageCameraShake.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
@@ -1651,6 +1651,8 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Actors\GameManager.cpp" />
     <ClCompile Include="LuaScripts\LuaUIBind.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Actors\Camera.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Actors\StreetLight.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Animation\AnimDelegateNotify.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="EngineSIU.natvis" />
@@ -1823,6 +1825,8 @@
     <ClInclude Include="LuaScripts\LuaUIBind.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Actors\Camera.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Actors\StreetLight.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Animation\AnimDelegateNotify.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\CompositingShader.hlsl" />


### PR DESCRIPTION
- DelegateNotify

## 주요 변경사항

### Anim Delegate Notify
아래 샘플 코드와 같이 원하는 Notify time에 맞추어 호출되는 함수를 바인딩할 수 있습니다
```
void APlayer::BindAnimNotifys()
{
    UAnimSequenceBase* AttackAnim = Cast<UAnimSequenceBase>(UAssetManager::Get().GetAnimation(FName("Contents/Player_3TTook/Armature|Armature|Armature|Left_Hook")));
    int32 TrackIdx = UAnimSequenceBase::EnsureNotifyTrack(AttackAnim, FName(TEXT("Default")));
    if (TrackIdx == INDEX_NONE)
    {
        return;
    }
    int32 NewNotifyIndex = INDEX_NONE;
    float NotifyTime = 0.1f;
    bool bAdded = AttackAnim->AddDelegateNotifyEventAndBind<APlayer>(TrackIdx, NotifyTime, this, &APlayer::OnStartAttack, NewNotifyIndex);

    NewNotifyIndex = INDEX_NONE;
    NotifyTime = 0.9f;
    bAdded = AttackAnim->AddDelegateNotifyEventAndBind<APlayer>(TrackIdx, NotifyTime, this, &APlayer::OnFinishAttack, NewNotifyIndex);

}
```

단, 해당 함수에서는 자신 외 인스턴스를 판별하기 위해 if (MeshComp != SkeletalMeshComponent) { return; } 등의 작업 수행 필요
